### PR TITLE
Update cpi crate

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
+checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
 
 [[package]]
 name = "arrayref"
@@ -445,12 +445,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
 dependencies = [
+ "js-sys",
  "num-integer",
  "num-traits",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -745,9 +747,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "serde",
  "typenum",
@@ -866,9 +868,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indoc"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a0bd019339e5d968b37855180087b7b9d512c5046fbd244cf8c95687927d6e"
+checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
 
 [[package]]
 name = "instant"
@@ -899,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
@@ -926,9 +928,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
 
 [[package]]
 name = "libsecp256k1"
@@ -1000,7 +1002,7 @@ dependencies = [
 [[package]]
 name = "mango"
 version = "3.5.1"
-source = "git+https://github.com/mrgnlabs/mango-v3.git?rev=3589b9d35beb6a01921bc32112b694e00dfb7ccc#3589b9d35beb6a01921bc32112b694e00dfb7ccc"
+source = "git+https://github.com/mrgnlabs/mango-v3.git?tag=v3.5.1-fork.1#f0b5462c3267ea4967fbe93ccd28b47fc1d9753a"
 dependencies = [
  "anchor-lang",
  "arrayref",
@@ -1010,7 +1012,7 @@ dependencies = [
  "enumflags2",
  "fixed",
  "fixed-macro",
- "mango-common 3.0.0 (git+https://github.com/mrgnlabs/mango-v3.git?rev=3589b9d35beb6a01921bc32112b694e00dfb7ccc)",
+ "mango-common 3.0.0 (git+https://github.com/mrgnlabs/mango-v3.git?tag=v3.5.1-fork.1)",
  "mango-logs",
  "mango-macro",
  "num_enum",
@@ -1029,7 +1031,7 @@ dependencies = [
 [[package]]
 name = "mango-common"
 version = "3.0.0"
-source = "git+https://github.com/mrgnlabs/mango-v3.git?rev=3589b9d35beb6a01921bc32112b694e00dfb7ccc#3589b9d35beb6a01921bc32112b694e00dfb7ccc"
+source = "git+https://github.com/mrgnlabs/mango-v3.git?tag=v3.5.1-fork.1#f0b5462c3267ea4967fbe93ccd28b47fc1d9753a"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1047,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "mango-logs"
 version = "0.1.0"
-source = "git+https://github.com/mrgnlabs/mango-v3.git?rev=3589b9d35beb6a01921bc32112b694e00dfb7ccc#3589b9d35beb6a01921bc32112b694e00dfb7ccc"
+source = "git+https://github.com/mrgnlabs/mango-v3.git?tag=v3.5.1-fork.1#f0b5462c3267ea4967fbe93ccd28b47fc1d9753a"
 dependencies = [
  "anchor-lang",
  "base64 0.13.0",
@@ -1056,10 +1058,10 @@ dependencies = [
 [[package]]
 name = "mango-macro"
 version = "3.0.0"
-source = "git+https://github.com/mrgnlabs/mango-v3.git?rev=3589b9d35beb6a01921bc32112b694e00dfb7ccc#3589b9d35beb6a01921bc32112b694e00dfb7ccc"
+source = "git+https://github.com/mrgnlabs/mango-v3.git?tag=v3.5.1-fork.1#f0b5462c3267ea4967fbe93ccd28b47fc1d9753a"
 dependencies = [
  "bytemuck",
- "mango-common 3.0.0 (git+https://github.com/mrgnlabs/mango-v3.git?rev=3589b9d35beb6a01921bc32112b694e00dfb7ccc)",
+ "mango-common 3.0.0 (git+https://github.com/mrgnlabs/mango-v3.git?tag=v3.5.1-fork.1)",
  "quote",
  "safe-transmute",
  "solana-program",
@@ -1173,7 +1175,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 1.2.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1250,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
+checksum = "9423e2b32f7a043629287a536f21951e8c6a82482d0acb1eeebfc90bc2225b22"
 
 [[package]]
 name = "pbkdf2"
@@ -1271,9 +1273,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823635055522a82e92ebd61dbe07ce53e180c8989cced4715eaec10baa1baeb7"
+checksum = "69486e2b8c2d2aeb9762db7b4e00b0331156393555cff467f4163ff06821eef8"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1296,10 +1298,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "26d50bfb8c23f23915855a00d98b5a35ef2e0b871bb52937bacadb798fbb66c8"
 dependencies = [
+ "once_cell",
  "thiserror",
  "toml",
 ]
@@ -1330,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
@@ -1445,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -1521,9 +1524,9 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rust_decimal"
-version = "1.25.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a3bb58e85333f1ab191bf979104b586ebd77475bc6681882825f4532dfe87c"
+checksum = "ee9164faf726e4f3ece4978b25ca877ddc6802fa77f38cdccb32c7f805ecd70c"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -1532,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal_macros"
-version = "1.25.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1467556c7c115165aa0346bcf45bc947203bcc880efad85a09ba24ea17926c4"
+checksum = "4903d8db81d2321699ca8318035d6ff805c548868df435813968795a802171b2"
 dependencies = [
  "quote",
  "rust_decimal",
@@ -1561,20 +1564,20 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.12",
+ "semver 1.0.13",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "safe-transmute"
@@ -1599,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
+checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "semver-parser"
@@ -1614,27 +1617,27 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
+checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212e73464ebcde48d723aa02eb270ba62eff38a9b732df31f33f1b4e145f3a54"
+checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
+checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1643,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa",
  "ryu",
@@ -1935,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2014,9 +2017,9 @@ checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2032,9 +2035,9 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "unindent"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fee519a3e570f7df377a06a1a7775cdbfb7aa460be7e08de2b1f0e69973a44"
+checksum = "58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112"
 
 [[package]]
 name = "uriparse"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 pyo3 = { version = "^0.16.5", features = ["extension-module", "abi3-py310"] }
 marginfi-common = { path = "../rust/marginfi-common" }
 bytemuck = "^1.7.2"
-mango-protocol = { git = "https://github.com/mrgnlabs/mango-v3.git", rev="3589b9d35beb6a01921bc32112b694e00dfb7ccc", package= "mango", features = ["no-entrypoint", "client"] }
+mango-protocol = { git = "https://github.com/mrgnlabs/mango-v3.git", tag="v3.5.1-fork.1", package= "mango", features = ["no-entrypoint", "client"] }
 mango-common = { git = "https://github.com/blockworks-foundation/mango-v3", gitref = "f4294688fb00ff18b2bf0b730d79ce005f7d124e" }
 serum_dex = { git = "https://github.com/blockworks-foundation/serum-dex.git", rev = "7f55a5ef5f7937b74381a3124021a261cd7d7283", default-features=false, features = ["no-entrypoint", "program"] }
 solana-sdk = "^1.9.13"

--- a/python/rust-toolchain
+++ b/python/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/rust/marginfi-common/Cargo.toml
+++ b/rust/marginfi-common/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mango-protocol = { git = "https://github.com/mrgnlabs/mango-v3.git", rev="3589b9d35beb6a01921bc32112b694e00dfb7ccc", package= "mango", features = ["no-entrypoint", "client"] }
+mango-protocol = { git = "https://github.com/mrgnlabs/mango-v3.git", tag="v3.5.1-fork.1", package= "mango", features = ["no-entrypoint", "client"] }
 serum_dex = { git = "https://github.com/blockworks-foundation/serum-dex.git", rev = "7f55a5ef5f7937b74381a3124021a261cd7d7283", default-features=false, features = ["no-entrypoint", "program"] }
 zo-abi = { git = "https://github.com/01protocol/zo-abi.git", rev = "3ff8def2c747899c9d534f5de36988b6f0a0d46c", features = [
     "cpi",

--- a/rust/marginfi-cpi/Cargo.toml
+++ b/rust/marginfi-cpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marginfi-cpi"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license-file = "LICENSE"
 description = "marginfi CPI interface"

--- a/rust/marginfi-cpi/example/programs/example-cpi/README.md
+++ b/rust/marginfi-cpi/example/programs/example-cpi/README.md
@@ -11,4 +11,5 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
    - the `programs.devnet` entry in `Anchor.toml`, and
    - `declare_id` in `lib.rs`
 1. Deploy the program to devnet: `$ anchor deploy` (automatically pointed towards mainnet through the `provider` entry in `Anchor.toml`)
+1. Install NPM dependencies: `$ yarn`
 1. Run the test suite: `$ anchor test --skip-deploy`

--- a/rust/marginfi-cpi/src/lib.rs
+++ b/rust/marginfi-cpi/src/lib.rs
@@ -9,17 +9,11 @@ anchor_gen::generate_cpi_interface!(
         MarginfiGroup,
         MarginfiAccount,
         UTPAccountConfig,
-        MDecimal,
+        WrappedI80F48,
         UTPConfig,
         Bank,
     ),
-    packed(
-        MarginfiGroup,
-        MarginfiAccount,
-        UTPAccountConfig,
-        Bank,
-        MDecimal
-    )
+    packed(MarginfiGroup, MarginfiAccount, UTPAccountConfig, Bank)
 );
 
 impl Default for state::MarginfiGroup {


### PR DESCRIPTION
* update + publish CPI crate
* prevent python SDK ARM build by default on M1
* revert mango fork to `const_assert`s and use tags for clarity